### PR TITLE
Fix to get userId into the jwt payload

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -20,6 +20,13 @@ module.exports = function () {
     before: {
       create: [
         iff(hook => hook.data.strategy === 'local', disallow('external')),
+        iff(hook => hook.data.strategy === 'local', hook => {
+          const query = { email: hook.data.email }
+          return hook.app.service('users').find({ query }).then(users => {
+            hook.params.payload = { userId: users.data[0]._id }
+            return hook
+          })
+        }),
         authentication.hooks.authenticate(config.strategies)
       ],
       remove: [


### PR DESCRIPTION
When initiating the local authentication strategy from the server, the userId isn't put into the jwt token.  The fix/workaround is to add the userId to hook.params.payload prior to calling the `before create` authentication hook.